### PR TITLE
Stop parsing if issue in substitution strings

### DIFF
--- a/src/FileToBeSaved.php
+++ b/src/FileToBeSaved.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright (c) Enalean, 2019 - Present. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Tab2Gettext;
+
+use PhpParser\NodeDumper;
+use PhpParser\PrettyPrinter;
+
+class FileToBeSaved
+{
+    /**
+     * @var string
+     */
+    private $path;
+    /**
+     * @var array|\PhpParser\Node[]
+     */
+    private $new_statements;
+    /**
+     * @var array|\PhpParser\Node\Stmt[]
+     */
+    private $old_statements;
+    /**
+     * @var array
+     */
+    private $old_tokens;
+
+    /**
+     * @param string $path
+     * @param \PhpParser\Node[] $new_statements
+     * @param \PhpParser\Node\Stmt[] $old_statements
+     * @param array $old_tokens
+     */
+    public function __construct(string $path, array $new_statements, array $old_statements, array $old_tokens)
+    {
+        $this->path = $path;
+        $this->new_statements = $new_statements;
+        $this->old_statements = $old_statements;
+        $this->old_tokens = $old_tokens;
+    }
+
+    public function save()
+    {
+        $printer = new PrettyPrinter\Standard();
+        $new_code = $printer->printFormatPreserving($this->new_statements, $this->old_statements, $this->old_tokens);
+
+        file_put_contents($this->path, $new_code);
+    }
+
+    public function printStatments()
+    {
+        $dumper = new NodeDumper;
+        echo $dumper->dump($this->new_statements) . "\n";
+    }
+}

--- a/src/MismatchSubstitutionCountException.php
+++ b/src/MismatchSubstitutionCountException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright (c) Enalean, 2019 - Present. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Tab2Gettext;
+
+class MismatchSubstitutionCountException extends \RuntimeException
+{
+}

--- a/src/SprintfSubstitution.php
+++ b/src/SprintfSubstitution.php
@@ -8,8 +8,22 @@ namespace Tab2Gettext;
 
 final class SprintfSubstitution
 {
+    private const PATTERN = '/\$(\d+)/';
+
     public static function convertFromTabFormat(string $string): string
     {
-        return preg_replace('/\$(\d+)/', '%\1\$s', $string);
+        return preg_replace(self::PATTERN, '%\1\$s', $string);
+    }
+
+    public static function countSubstitutions(string $value): int
+    {
+        $nb = preg_match_all(self::PATTERN, $value, $matches, PREG_SET_ORDER);
+        if (! $nb) {
+            return 0;
+        }
+
+        $substitutions = array_column($matches, 1);
+
+        return (int) max($substitutions);
     }
 }

--- a/tests/SprintfSubstitutionTest.php
+++ b/tests/SprintfSubstitutionTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright (c) Enalean, 2019 - Present. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Tab2Gettext;
+
+use PHPUnit\Framework\TestCase;
+
+class SprintfSubstitutionTest extends TestCase
+{
+    /**
+     * @dataProvider provideSubstitutions
+     */
+    public function testSubstitutions(int $count, string $sentence): void
+    {
+        $this->assertEquals($count, SprintfSubstitution::countSubstitutions($sentence));
+    }
+
+    public function provideSubstitutions(): array
+    {
+        return [
+            [0, ''],
+            [0, 'Simple sentence'],
+            [1, 'With $1 substitution'],
+            [2, 'With $1 substitution $2'],
+            [2, 'With $2 substitution $1'],
+            [2, 'With substitution $2'],
+        ];
+    }
+}

--- a/tests/_expected/plugins/tracker/include/Foo.php
+++ b/tests/_expected/plugins/tracker/include/Foo.php
@@ -17,7 +17,6 @@ class trackerPluginDescriptor extends PluginDescriptor {
         sprintf(dgettext('tuleap-tracker', '%1$s projects restriction'), $this->plugin->getPluginInfo()->getPluginDescriptor()->getFullName());
         sprintf(dgettext('tuleap-tracker', '%1$s projects restriction'), $this->plugin->getPluginInfo()->getPluginDescriptor()->getFullName());
         sprintf(dgettext('tuleap-tracker', '%2$s blah %1$s'), $a, $b);
-        sprintf(dgettext('tuleap-tracker', '%2$s blah %1$s'), $a, $b);
 
         // ignore such expressions
         $this->$method();

--- a/tests/_fixtures/plugins/tracker/include/Foo.php
+++ b/tests/_fixtures/plugins/tracker/include/Foo.php
@@ -16,7 +16,6 @@ class trackerPluginDescriptor extends PluginDescriptor {
         // concatenations
         $GLOBALS['Language']->getText('plugin_tracker', 'plugin_allowed_project_title', array($this->plugin->getPluginInfo()->getPluginDescriptor()->getFullName()));
         $GLOBALS['Language']->getText('plugin_tracker', 'plugin_allowed_project_title', $this->plugin->getPluginInfo()->getPluginDescriptor()->getFullName());
-        $GLOBALS['Language']->getText('plugin_tracker', 'key_with_two_replacements', $a, $b);
         $GLOBALS['Language']->getText('plugin_tracker', 'key_with_two_replacements', [$a, $b]);
 
         // ignore such expressions


### PR DESCRIPTION
Given the following .tab file:

```
primary_key	secondary_key	Register a new $1 account
```

And the following php code:

```php
$Language->getText('primary_key', 'secondary_key');
```

Then the conversion should be stopped, because the substitution string
$1 is unused. We don't know how it should be fixed (missing 3rd
parameter in getText call? Or $1 to be removed?), therefore we should
ask for manual intervention.

Fix #1