### PR TITLE
Do not throw fatal error if key is unused

### DIFF
--- a/src/CodeInErrorException.php
+++ b/src/CodeInErrorException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) Enalean, 2019 - Present. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Tab2Gettext;
+
+use PhpParser\Node;
+
+class CodeInErrorException extends \RuntimeException
+{
+    public function __construct(string $message, Node $node, string $filepath)
+    {
+        $line = $node->getAttribute('startLine');
+        parent::__construct("$message in: $filepath at L$line");
+    }
+}

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -2,6 +2,7 @@
 /**
  * Copyright (c) Enalean, 2019. All Rights Reserved.
  */
+declare(strict_types=1);
 
 namespace Tab2Gettext;
 
@@ -22,7 +23,10 @@ class Dictionary
         return new self(include $filepath);
     }
 
-    public function get($primarykey, $secondarykey) {
+    public function get(string $primarykey, string $secondarykey): string {
+        if (! isset($this->entries[$primarykey][$secondarykey])) {
+            throw new EntryNotFoundException();
+        }
         return $this->entries[$primarykey][$secondarykey];
     }
 }

--- a/src/EntryNotFoundException.php
+++ b/src/EntryNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright (c) Enalean, 2019 - Present. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Tab2Gettext;
+
+class EntryNotFoundException extends \RuntimeException
+{
+}

--- a/src/MismatchSubstitutionCountException.php
+++ b/src/MismatchSubstitutionCountException.php
@@ -7,6 +7,16 @@ declare(strict_types=1);
 
 namespace Tab2Gettext;
 
-class MismatchSubstitutionCountException extends \RuntimeException
+use PhpParser\Node;
+
+class MismatchSubstitutionCountException extends CodeInErrorException
 {
+    public function __construct(int $expected_count, int $actual_count, string $sentence, Node $node, string $filepath)
+    {
+        parent::__construct(
+            "Expected substitution count differs (expected: $expected_count, actual: $actual_count) for: «${sentence}»",
+            $node,
+            $filepath
+        );
+    }
 }

--- a/src/SentenceNotFoundException.php
+++ b/src/SentenceNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright (c) Enalean, 2019 - Present. All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Tab2Gettext;
+
+use PhpParser\Node;
+
+class SentenceNotFoundException extends CodeInErrorException
+{
+    public function __construct(string $primary, string $secondary, Node $node, string $filepath)
+    {
+        parent::__construct("Cannot found ($primary, $secondary)", $node, $filepath);
+    }
+}

--- a/src/Tab2Gettext.php
+++ b/src/Tab2Gettext.php
@@ -57,6 +57,9 @@ class Tab2Gettext
         } catch (MismatchSubstitutionCountException $exception) {
             $this->logger->critical("Mismatch substitution count!");
             $this->logger->error($exception->getMessage());
+        } catch (SentenceNotFoundException $exception) {
+            $this->logger->critical("Sentence not found!");
+            $this->logger->error($exception->getMessage());
         }
     }
 

--- a/tests/Tab2GettextTest.php
+++ b/tests/Tab2GettextTest.php
@@ -84,9 +84,9 @@ class Tab2GettextTest extends TestCase
     }
 
     /**
-     * @dataProvider mismatchSubstitutionsCodeProvider
+     * @dataProvider codeInErrorProvider
      */
-    public function testConversionIsAbortedIfThereIsAnUnusedSubstitution(string $code)
+    public function testConversionIsAbortedIfThereIsAnError(string $code, string $error_message): void
     {
         $file = 'plugins/tracker/include/File.php';
         file_put_contents(
@@ -107,7 +107,7 @@ class Tab2GettextTest extends TestCase
         $logger->shouldReceive('info');
         $logger->shouldReceive('debug');
         $logger->shouldReceive('error');
-        $logger->shouldReceive('critical')->with("Mismatch substitution count!");
+        $logger->shouldReceive('critical')->with($error_message);
 
         $converter = new Tab2Gettext($logger);
         $converter->run(
@@ -132,11 +132,21 @@ class Tab2GettextTest extends TestCase
         $this->assertFilesAreTheSame($files_to_compare, $expected_dir);
     }
 
-    public function mismatchSubstitutionsCodeProvider(): array
+    public function codeInErrorProvider(): array
     {
         return [
-            ['<?php $Language->getText("plugin_tracker", "plugin_allowed_project_title");'],
-            ['<?php $Language->getText("plugin_tracker", "plugin_allowed_project_title", [$a, $b]);'],
+            [
+                '<?php $Language->getText("plugin_tracker", "plugin_allowed_project_title");',
+                'Mismatch substitution count!'
+            ],
+            [
+                '<?php $Language->getText("plugin_tracker", "plugin_allowed_project_title", [$a, $b]);',
+                'Mismatch substitution count!'
+            ],
+            [
+                '<?php $Language->getText("plugin_tracker", "Secondary key that cannot be found in dictionary");',
+                'Sentence not found!'
+            ],
         ];
     }
 


### PR DESCRIPTION
In the following php code:
```php
$Language->getText('plugin_git', 'Unable to update template');
```

`Unable to update template` is not a valid secondary key. It should
be `view_admin_template_cannot_update` according to the .tab file:
```
plugin_git	view_admin_template_cannot_update	Unable to update template
```

In this case the tab2gettext should not end up in a cryptic fatal error.